### PR TITLE
Fix declaration for module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,10 @@
 declare module 'clean-set' {
+  function cleanSet<A>(
+    source: A,
+    keys: string | string[],
+    update: <B>(value: B) => B
+  ): A;
+  function cleanSet<A>(source: A, keys: string | string[], update: any): A;
   /**
    * Update a value in a deeply nested object and clone each node touched
    * @param source The object to be updated
@@ -6,9 +12,5 @@ declare module 'clean-set' {
    * @param update Either a function that will receive the current value and return a new value OR the new value for the node
    * @returns The new object
    */
-  export default function<A>(
-    source: A,
-    keys: string | string[],
-    update: <B>(value: B) => B | any
-  ): A;
+  export default cleanSet;
 }


### PR DESCRIPTION
Hi! This library is pretty cool, thanks to all its contributors!

Using it with TS, I noticed a small error on the signatures: it always requires a callback and it doesn't accept types on it. This PR fixes that by providing two overloads to the exported function.

A reproducible example can be found [here](https://codesandbox.io/s/nice-bell-jotsu).
Instructions to reproduce the fix are there as well.

PS: The fix for setting `null`, provided [here](https://github.com/fwilkerson/clean-set/pull/4) hasn't been released yet.